### PR TITLE
Update deprecated path static template tag

### DIFF
--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.utils.html import format_html
 
 from wagtail.core import hooks


### PR DESCRIPTION
It seems that static template tags does not live here anymore 

Sources
- https://docs.wagtail.io/en/stable/reference/hooks.html#insert-global-admin-css
- https://github.com/django/django/tree/main/django/contrib/staticfiles